### PR TITLE
Update PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,29 +1,35 @@
 # Description
 
-Please include a summary of the changes, including screenshots, if applicable. Please also provide any motivation and context necessary to review these changes. List any dependencies that are required for this change.
+<!-- Please include a summary of the changes, including screenshots, if applicable. Please also provide any motivation and context necessary to review these changes. List any dependencies that are required for this change. -->
 
 ## Type of change
 
-Please delete options that are not relevant.
+<!-- Please delete options that are not relevant.
 
+- [ ] Chore (non-breaking change which has no end user impact)
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-
+ -->
+ 
 # Testing Plan
 
-Please describe the tests that you ran or will run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
+<!-- Please describe the tests that you ran or will run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 
 - [ ] Unit tests
 - [ ] Test in staging by doing X, Y, and Z
 
 **Test Configuration**:
 - Unit with active lease
-
+ -->
+ 
 # Checklist:
+
+<!-- Please delete options that are not relevant.
 
 - [ ] I have performed a self-review of my code
 - [ ] I have requested review from 2 engineers, at least one of which is on a different team
 - [ ] I have made corresponding changes to the documentation
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] Any dependent changes have been merged and published in downstream modules
+ -->

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -16,11 +16,10 @@
 
 <!-- Please describe the tests that you ran or will run to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.
 
-- [ ] Unit tests
-- [ ] Test in staging by doing X, Y, and Z
+- [ ] Add any plans you have for testing. Examples include testing locally, unit/integration tests, and manual testing in preview/staging environments.
 
 **Test Configuration**:
-- Unit with active lease
+- Add any necessary configuration for reviewers to test your change
  -->
  
 # Checklist:


### PR DESCRIPTION
- Add `chore` change type
- Enhance descriptions to make it more clear PR authors are expected to change the template
- Make everything comments by default so instructions to authors are not left in the PR description